### PR TITLE
feat: 산책 일지 월별 통계 기능 구현

### DIFF
--- a/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
+++ b/src/main/java/com/cocomoo/taily/controller/WalkDiaryController.java
@@ -1,10 +1,7 @@
 package com.cocomoo.taily.controller;
 
 import com.cocomoo.taily.dto.ApiResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryCreateRequestDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryDetailResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryListResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryUpdateRequestDto;
+import com.cocomoo.taily.dto.walkDiary.*;
 import com.cocomoo.taily.service.WalkDiaryService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -88,5 +85,15 @@ public class WalkDiaryController {
         walkDiaryService.deleteWalkDiary(id, username);
 
         return ResponseEntity.ok(ApiResponseDto.success(null, "산책 일지 삭제 성공"));
+    }
+
+    // 산책 일지 월간 통계
+    @GetMapping("/stats")
+    public ResponseEntity<?> getMonthlyStats() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String username = authentication.getName();
+
+        WalkDiaryStatsResponseDto statsDto = walkDiaryService.getMonthlyStats(username);
+        return ResponseEntity.ok(ApiResponseDto.success(statsDto, "월간 산책 통계 조회 성공"));
     }
 }

--- a/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryStatsResponseDto.java
+++ b/src/main/java/com/cocomoo/taily/dto/walkDiary/WalkDiaryStatsResponseDto.java
@@ -1,0 +1,38 @@
+package com.cocomoo.taily.dto.walkDiary;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class WalkDiaryStatsResponseDto {
+    private int totalWalks;
+    private double avgDurationMinutes;
+    private long streakDays;
+    private List<DailyStat> dailyStat;
+    private String reminderMessage;
+
+    @Getter
+    @AllArgsConstructor
+    public static class DailyStat {
+        private LocalDate date;
+        private Long durationMinutes;
+    }
+
+    public static WalkDiaryStatsResponseDto empty() {
+        return WalkDiaryStatsResponseDto.builder()
+                .totalWalks(0)
+                .avgDurationMinutes(0)
+                .streakDays(0)
+                .dailyStat(List.of())
+                .reminderMessage("이번 달에는 아직 산책 기록이 없어요 🐾")
+                .build();
+    }
+}

--- a/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
+++ b/src/main/java/com/cocomoo/taily/repository/WalkDiaryRepository.java
@@ -1,5 +1,6 @@
 package com.cocomoo.taily.repository;
 
+import com.cocomoo.taily.entity.User;
 import com.cocomoo.taily.entity.WalkDiary;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -27,4 +28,5 @@ public interface WalkDiaryRepository extends JpaRepository<WalkDiary, Long> {
     @Query("SELECT w FROM WalkDiary w JOIN FETCH w.user WHERE w.id = :id")
     Optional<WalkDiary> findByIdWithUser(Long id);
 
+    List<WalkDiary> findAllByUserAndDateBetween(User user, LocalDate startDate, LocalDate endDate);
 }

--- a/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
+++ b/src/main/java/com/cocomoo/taily/service/WalkDiaryService.java
@@ -1,10 +1,7 @@
 package com.cocomoo.taily.service;
 
 import com.cocomoo.taily.dto.common.image.ImageResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryCreateRequestDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryDetailResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryListResponseDto;
-import com.cocomoo.taily.dto.walkDiary.WalkDiaryUpdateRequestDto;
+import com.cocomoo.taily.dto.walkDiary.*;
 import com.cocomoo.taily.entity.Image;
 import com.cocomoo.taily.entity.TableType;
 import com.cocomoo.taily.entity.User;
@@ -18,6 +15,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.Duration;
 import java.time.LocalDate;
 import java.time.YearMonth;
 import java.util.ArrayList;
@@ -231,5 +229,70 @@ public class WalkDiaryService {
         }
 
         walkDairyRepository.delete(walkDiary);
+    }
+
+    public WalkDiaryStatsResponseDto getMonthlyStats(String username) {
+        // 작성자 조회
+        User user = userRepository.findByUsername(username).orElseThrow(() -> new IllegalArgumentException("존재하지 않는 회원입니다. "));
+
+        LocalDate startOfMonth = LocalDate.now().withDayOfMonth(1);
+        LocalDate endOfMonth = startOfMonth.plusMonths(1).minusDays(1);
+
+        List<WalkDiary> walkDiaries = walkDairyRepository.findAllByUserAndDateBetween(user, startOfMonth, endOfMonth);
+
+        if (walkDiaries.isEmpty()) {
+            return WalkDiaryStatsResponseDto.empty();
+        }
+
+        // 총 산책 횟수
+        int totalWalks = walkDiaries.size();
+        // 평균 시간 계산
+        double avgMinutes = walkDiaries.stream().mapToLong(d -> Duration.between(d.getBeginTime(), d.getEndTime()).toMinutes()).average().orElse(0);
+        // 연속 산책 일수 계산
+        long streakDays = calculateStreak(walkDiaries);
+        // 날짜별 산책 시간
+        List<WalkDiaryStatsResponseDto.DailyStat> dailyStats = walkDiaries.stream().map(d -> new WalkDiaryStatsResponseDto.DailyStat(
+                d.getDate(),
+                Duration.between(d.getBeginTime(), d.getEndTime()).toMinutes()
+        )).toList();
+        // 알림 문구
+        String reminderMessage = createReminderMessage(walkDiaries);
+
+        return new WalkDiaryStatsResponseDto(
+                totalWalks,
+                avgMinutes,
+                streakDays,
+                dailyStats,
+                reminderMessage
+        );
+    }
+
+    // 통계 도와주는 메서드 - 추후 entity로 이동
+    private long calculateStreak(List<WalkDiary> diaries) {
+        List<LocalDate> sortedDates = diaries.stream()
+                .map(WalkDiary::getDate)
+                .sorted()
+                .toList();
+
+        long streak = 1, maxStreak = 1;
+        for (int i = 1; i < sortedDates.size(); i++) {
+            if (sortedDates.get(i).minusDays(1).equals(sortedDates.get(i - 1))) {
+                streak++;
+                maxStreak = Math.max(maxStreak, streak);
+            } else streak = 1;
+        }
+        return maxStreak;
+    }
+
+    private String createReminderMessage(List<WalkDiary> diaries) {
+        LocalDate lastDate = diaries.stream()
+                .map(WalkDiary::getDate)
+                .max(LocalDate::compareTo)
+                .orElse(LocalDate.now());
+
+        if (lastDate.isBefore(LocalDate.now().minusDays(7))) {
+            return "이번 주는 아직 산책을 안했어요 😢";
+        }
+        return "저번 주보다 산책 시간이 더 늘었어요! 👏";
     }
 }


### PR DESCRIPTION
# 📑 PR 요약
산책 일지 월별 통계 기능 구현

## 🔗 관련 이슈

<!-- 관련있는 이슈 번호(#000)을 적어주세요. 해당 pull request merge와 함께 이슈를 닫으려면 closed #이슈 번호를 적어주세요 -->

## ☑ 작업 내용
- 산책 일지 월별 통계 기능 구현
- WalkDiaryStatsResponseDto 생성 후 필요한 기능들 추가 하여 구현 (총 산책 수, 평균 산책 시간, 연속 일 수, 일자 별 통계, 리마인더 메시지)

## 단위 테스트 결과
<img width="797" height="927" alt="image" src="https://github.com/user-attachments/assets/8710d728-a399-4739-98c6-dbee10b8473a" />

## ✅ 기타 사항
